### PR TITLE
Force utf-8 encoding for bundled js files

### DIFF
--- a/src/metapensiero/pj/api.py
+++ b/src/metapensiero/pj/api.py
@@ -260,7 +260,7 @@ def evaljs(js_text, load_es6_polyfill=False, **kwargs):
     else:
         list(js_text)
     if load_es6_polyfill:
-        with open(BABEL_POLYFILL, 'r') as babel_poly:
+        with open(BABEL_POLYFILL, 'r', encoding='utf-8') as babel_poly:
             js_text = ['global = this; this.console = {log: print};\n'] + [babel_poly.read()] + js_text
     return dukpy.evaljs(js_text, **kwargs)
 
@@ -319,7 +319,7 @@ def babel_compile(source, reuse_js_ctx=True, **kwargs):
         result = BABEL_JS_CTX.evaljs(trans_code, es6code=source,
                                      babel_options=kwargs)
     else:
-        with open(BABEL_COMPILER, 'r') as babel_js:
+        with open(BABEL_COMPILER, 'r', encoding='utf-8') as babel_js:
             if reuse_js_ctx:
                 BABEL_JS_CTX = dukpy.JSInterpreter()
                 eval_fn = BABEL_JS_CTX.evaljs


### PR DESCRIPTION
On some systems there are errors with unrecognized characters. Since bundled js files are utf-8 encoded it's safe to use utf-8 encoding for them.