### PR TITLE
Using os-specific path separator

### DIFF
--- a/src/metapensiero/pj/processor/util.py
+++ b/src/metapensiero/pj/processor/util.py
@@ -10,9 +10,9 @@ import ast
 import inspect
 import re
 import textwrap
+import os.path
 
 from . import sourcemaps
-from os import sep
 
 
 IGNORED_NAMES = ('__all__',)
@@ -51,10 +51,7 @@ def delimited_multi_line(node, text, begin=None, end=None, add_space=False):
 
 
 def parent_of(path):
-    if sep in path:
-        return sep.join(path.rstrip(sep).split(sep)[:-1])
-    return '/'.join(path.rstrip('/').split('/')[:-1])
-
+    return os.path.split(os.path.normpath(path))[0]
 
 def body_top_names(body):
     names = set()

--- a/src/metapensiero/pj/processor/util.py
+++ b/src/metapensiero/pj/processor/util.py
@@ -12,6 +12,7 @@ import re
 import textwrap
 
 from . import sourcemaps
+from os import sep
 
 
 IGNORED_NAMES = ('__all__',)
@@ -50,6 +51,8 @@ def delimited_multi_line(node, text, begin=None, end=None, add_space=False):
 
 
 def parent_of(path):
+    if sep in path:
+        return sep.join(path.rstrip(sep).split(sep)[:-1])
     return '/'.join(path.rstrip('/').split('/')[:-1])
 
 


### PR DESCRIPTION
On Window path separator is backslash \
Splitting by '/' leads to weird bugs like "The system cannot find the path specified: ''"