### PR TITLE
Add support for Python 3 typehints

### DIFF
--- a/src/metapensiero/pj/__main__.py
+++ b/src/metapensiero/pj/__main__.py
@@ -252,7 +252,7 @@ def main(args=None, fout=None, ferr=None):
                     rep.print_err("An error occurred while compiling source "
                                   "file '%s'" % src_fname)
                 else:
-                    rep.print_err("An error occured during processing.")
+                    rep.print_err("An error occurred during processing.")
                 rep.print_err(error)
             result = 1
     sys.exit(result)

--- a/src/metapensiero/pj/processor/util.py
+++ b/src/metapensiero/pj/processor/util.py
@@ -109,6 +109,17 @@ def body_local_names(body):
     return names
 
 
+def get_assign_targets(py_node):
+    if isinstance(py_node, ast.Assign):
+        return py_node.targets
+    elif isinstance(py_node, ast.AnnAssign):
+        return [py_node.target]
+    else:
+        raise TypeError('Unsupported get_assign_targets type: {}'.format(
+            py_node.__class__.__name__
+        ))
+
+
 def node_names(py_node):
     """Extract 'names' from a Python node. Names are all those interesting
     for the enclosing scope.
@@ -125,8 +136,8 @@ def node_names(py_node):
 
     """
     names = set()
-    if isinstance(py_node, ast.Assign):
-        for el in py_node.targets:
+    if isinstance(py_node, (ast.Assign, ast.AnnAssign)):
+        for el in get_assign_targets(py_node):
             if isinstance(el, ast.Name) and el.id not in \
                IGNORED_NAMES:
                 names.add(el.id)

--- a/src/metapensiero/pj/transformations/obvious.py
+++ b/src/metapensiero/pj/transformations/obvious.py
@@ -77,6 +77,9 @@ def Assign_default(t, x):
         y = JSAssignmentExpression(x.targets[-(2 + i)], y)
     return JSExpressionStatement(y)
 
+# Python 3 typehints are accepted and ignored
+def AnnAssign(t, x):
+    return JSExpressionStatement(JSAssignmentExpression(x.target, x.value))
 
 def Assign_all(t, x):
     if len(x.targets) == 1 and isinstance(x.targets[0], ast.Name) and \


### PR DESCRIPTION
This allows you to use Python 3 typehints (`AnnAssign` nodes). The transpiler simply ignores the typehints and treats them as if they were normal assignment nodes.