### PR TITLE
ENH: Support Python 3.8

### DIFF
--- a/src/metapensiero/pj/transformations/obvious.py
+++ b/src/metapensiero/pj/transformations/obvious.py
@@ -281,13 +281,14 @@ def NameConstant(t, x):
 # Take care of Python 3.8's deprecations:
 # https://docs.python.org/3/library/ast.html#node-classes
 def Constant(t, x):
-    if isinstance(x.value, (int, float, complex)):
+    if isinstance(x.value, bool) or x.value is None:
+        return NameConstant(t, x)
+    elif isinstance(x.value, (int, float, complex)):
         return Num(t, x)
     elif isinstance(x.value, str):
         return Str(t, x)
     else:
-        return NameConstant(t, x)
-
+        raise ValueError('Unknown data type received.')
 
 def Yield(t, x):
     return JSYield(x.value)

--- a/src/metapensiero/pj/transformations/obvious.py
+++ b/src/metapensiero/pj/transformations/obvious.py
@@ -278,7 +278,15 @@ def NameConstant(t, x):
     return cls()
 
 
-Constant = NameConstant
+# Take care of Python 3.8's deprecations:
+# https://docs.python.org/3/library/ast.html#node-classes
+def Constant(t, x):
+    if isinstance(x, (float, complex)):
+        return Num(t, x)
+    elif isinstance(x, str):
+        return Str(t, x)
+    else:
+        return NameConstant(t, x)
 
 
 def Yield(t, x):

--- a/src/metapensiero/pj/transformations/obvious.py
+++ b/src/metapensiero/pj/transformations/obvious.py
@@ -281,9 +281,9 @@ def NameConstant(t, x):
 # Take care of Python 3.8's deprecations:
 # https://docs.python.org/3/library/ast.html#node-classes
 def Constant(t, x):
-    if isinstance(x, (float, complex)):
+    if isinstance(x.value, (int, float, complex)):
         return Num(t, x)
-    elif isinstance(x, str):
+    elif isinstance(x.value, str):
         return Str(t, x)
     else:
         return NameConstant(t, x)

--- a/src/metapensiero/pj/transformations/obvious.py
+++ b/src/metapensiero/pj/transformations/obvious.py
@@ -278,6 +278,9 @@ def NameConstant(t, x):
     return cls()
 
 
+Constant = NameConstant
+
+
 def Yield(t, x):
     return JSYield(x.value)
 


### PR DESCRIPTION
https://docs.python.org/3/library/ast.html#node-classes

> Deprecated since version 3.8: Class ast.Constant is now used for all constants. Old classes ast.Num, ast.Str, ast.Bytes, ast.NameConstant and ast.Ellipsis are still available, but they will be removed in future Python releases.

Ran into trouble with Python 3.8.1 for `NameConstant` bc of this change.