### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,7 @@ Brief list of the supported Python semantics
 The fact that JavaScripthon doesn't *reinvent the wheel* by reimplementing in
 Python many of the features available with JavaScript translators/transpilers
 allows it to be lean while implementing quite a decent set of the core Python
-semanticts. These are, briefly:
+semantics. These are, briefly:
 
 * Misc
 
@@ -130,7 +130,7 @@ semanticts. These are, briefly:
   - ``__instancecheck__`` to ``[Symbol.hasInstance]``;
   - ``int`` to ``parseInt``;
   - ``float`` to ``parseFloat``;
-  - dictionary keys are unanbiguous when ES6 translation is
+  - dictionary keys are unambiguous when ES6 translation is
     enabled. For example the following code gets translated correctly:
 
     .. code:: python
@@ -986,7 +986,7 @@ implemented yet.
             }
         }
 
-Only direct descendants of ``Exception`` are threated especially, but
+Only direct descendants of ``Exception`` are treated especially, but
 just for them to be meaningful in JS land and to be detectable with
 ``instanceof`` in catch statements.
 
@@ -1388,6 +1388,6 @@ __ https://news.ycombinator.com/item?id=11203183
 
 __ http://kangax.github.io/compat-table/es6/
 
-* `A story`__ about ES6 crazyest stuff... symbols
+* `A story`__ about ES6 craziest stuff... symbols
 
 __ http://blog.keithcirkel.co.uk/metaprogramming-in-es6-symbols/

--- a/src/metapensiero/pj/api.py
+++ b/src/metapensiero/pj/api.py
@@ -316,7 +316,7 @@ BABEL_JS_CTX = None
 
 
 def babel_compile(source, reuse_js_ctx=True, **kwargs):
-    """Compile the given `source` from ES6 to ES5 usin Babeljs."""
+    """Compile the given `source` from ES6 to ES5 using Babeljs."""
     global BABEL_JS_CTX
     presets = kwargs.get('presets')
     if not presets:

--- a/src/metapensiero/pj/processor/sourcemaps.py
+++ b/src/metapensiero/pj/processor/sourcemaps.py
@@ -230,7 +230,7 @@ class SourceMap:
         if isinstance(source, dict):
             smap = source
         else:
-            # According to the spec a souce map may be prepended with
+            # According to the spec a source map may be prepended with
             # ")]}'" to cause a JavaScript error. In that case ignore the
             # entire first line.
             if source[:4] == ")]}'":

--- a/src/metapensiero/pj/transformations/comprehensions.py
+++ b/src/metapensiero/pj/transformations/comprehensions.py
@@ -53,7 +53,7 @@ def ListComp(t, x):
     __i = t.new_name()
     __bound = t.new_name()
 
-    # Let's contruct the result from the inside out:
+    # Let's construct the result from the inside out:
     #<pre>__new.push(EXPR);</pre>
     push = JSExpressionStatement(
             JSCall(

--- a/src/metapensiero/pj/transformations/special.py
+++ b/src/metapensiero/pj/transformations/special.py
@@ -362,7 +362,7 @@ _shortcuts = {
 def _notable_replacer_gen():
     """This is used together with 'GEN_PREFIX_RE' to replace unicode
     symbol names in module prefixes. Some names are shortcut using the
-    ``_shortcuts`` map. It's designed to replace matches olny if they
+    ``_shortcuts`` map. It's designed to replace matches only if they
     are located at the beginning of the string and if they are
     subsequent to one another. It returns a function to be used with a
     regular expression object ``sub()`` method.


### PR DESCRIPTION
There are small typos in:
- README.rst
- src/metapensiero/pj/api.py
- src/metapensiero/pj/processor/sourcemaps.py
- src/metapensiero/pj/transformations/comprehensions.py
- src/metapensiero/pj/transformations/special.py

Fixes:
- Should read `unambiguous` rather than `unanbiguous`.
- Should read `semantics` rather than `semanticts`.
- Should read `craziest` rather than `crazyest`.
- Should read `construct` rather than `contruct`.
- Should read `treated` rather than `threated`.
- Should read `source` rather than `souce`.
- Should read `only` rather than `olny`.
- Should read `using` rather than `usin`.

Closes #59