### PR TITLE
Update snippets to use enums

### DIFF
--- a/src/metapensiero/pj/snippets.py
+++ b/src/metapensiero/pj/snippets.py
@@ -5,6 +5,7 @@
 # :License:  GNU General Public License version 3 or later
 #
 
+from enum import Enum
 
 def _in(left, right):
     from __globals__ import Array, typeof
@@ -54,7 +55,15 @@ def set_properties(cls, props):
 
     for p in dict(props):
         value = props[p]
-        if not isinstance(value, (Map, WeakMap)) and isinstance(value, Object) \
+        if Object.getPrototypeOf(cls) == Enum:
+            desc = {
+                'value': { 'name': p, 'value': value },
+                'enumerable': False,
+                'configurable': True,
+                'writable': True
+            }
+            Object.defineProperty(cls, p, desc)
+        elif not isinstance(value, (Map, WeakMap)) and isinstance(value, Object) \
            and 'get' in value and isinstance(value.get, Function):
             # the following condition raises a TypeError in dukpy, why?
             # ('set' in value and isinstance(value.set, Function)):


### PR DESCRIPTION
When a class extends enum.Enum you have to define the properties at class level. Also the values need to be an object with "name" and "value" properties.
