### PR TITLE
fix: Allow ast.Subscript as indices

### DIFF
--- a/src/metapensiero/pj/transformations/obvious.py
+++ b/src/metapensiero/pj/transformations/obvious.py
@@ -198,7 +198,7 @@ def Attribute_default(t, x):
 
 def Subscript_default(t, x):
     if is_py39:
-        assert isinstance(x.slice, (ast.Constant, ast.Name))
+        assert isinstance(x.slice, (ast.Constant, ast.Name, ast.Subscript))
         v = x.slice
     else:
         v = x.slice.value

--- a/src/metapensiero/pj/transformations/obvious.py
+++ b/src/metapensiero/pj/transformations/obvious.py
@@ -198,7 +198,7 @@ def Attribute_default(t, x):
 
 def Subscript_default(t, x):
     if is_py39:
-        assert isinstance(x.slice, (ast.Constant, ast.Name, ast.Subscript))
+        assert isinstance(x.slice, (ast.Constant, ast.Name, ast.Subscript, ast.UnaryOp))
         v = x.slice
     else:
         v = x.slice.value


### PR DESCRIPTION
e.g. `a[b[0]]` previously errored as `b[0]` is considered a node of the wrong type (ast.Subscript)

I'm not overly familiar with the inner workings of metapensiero having mostly worked on a "chickens go in pies come out" basis via PsychoPy, so please do let me know if there's unforseen consequences to this change!

Also fixes #78
