### PR TITLE
Allow attribute to be used as an index

### DIFF
--- a/src/metapensiero/pj/transformations/obvious.py
+++ b/src/metapensiero/pj/transformations/obvious.py
@@ -198,7 +198,7 @@ def Attribute_default(t, x):
 
 def Subscript_default(t, x):
     if is_py39:
-        assert isinstance(x.slice, (ast.Constant, ast.Name, ast.Subscript, ast.UnaryOp))
+        assert isinstance(x.slice, (ast.Constant, ast.Name, ast.Subscript, ast.UnaryOp, ast.Attribute))
         v = x.slice
     else:
         v = x.slice.value


### PR DESCRIPTION
Same as my last PR (#81), a collaborator found a class of index which doesn't translate. 

This is quite typical to do in PsychoPy:
```
stimuli = ["a.png", "b.png", "c.png"]
trials = TrialHandler(...)
for trial in trials:
    stim = stimuli[trials.thisN]
```
and we've found that `stimuli[trials.thisN]` doesn't translate as `trials.thisN` is an `ast.Attribute` and this isn't included in the assertion for adding a slice.